### PR TITLE
Add initial support for the mdtool setup utility

### DIFF
--- a/Cake.Xamarin/Aliases.cs
+++ b/Cake.Xamarin/Aliases.cs
@@ -91,6 +91,18 @@ namespace Cake.Xamarin
         }
 
         /// <summary>
+        /// Gets a runner for invoking the Xamarin Studio Add-in Setup Utility.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <returns>A setup utility runner.</returns>
+        [CakePropertyAlias]
+        public static MDToolSetupRunner MDToolSetup (this ICakeContext context)
+        {
+            var runner = new MDToolSetupRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber);
+            return runner;
+        }
+
+        /// <summary>
         /// Restores Xamarin Components for a given project
         /// </summary>
         /// <param name="context">The context.</param>

--- a/Cake.Xamarin/Cake.Xamarin.csproj
+++ b/Cake.Xamarin/Cake.Xamarin.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -41,6 +41,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="MDToolSetupRunner.cs" />
+    <Compile Include="MDToolSetupSettings.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="MDToolRunner.cs" />
     <Compile Include="XamarinComponentRunner.cs" />

--- a/Cake.Xamarin/MDToolSetupRunner.cs
+++ b/Cake.Xamarin/MDToolSetupRunner.cs
@@ -1,0 +1,89 @@
+﻿using System.Collections.Generic;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Xamarin
+{
+    /// <summary>
+    /// A wrapper around the Xamarin Studio Add-in Setup Utility (<c>mdtool setup</c>).
+    /// </summary>
+    public class MDToolSetupRunner : Tool<MDToolSetupSettings>
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MDToolSetupRunner" /> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system</param>
+        /// <param name="environment">The environment</param>
+        /// <param name="processRunner">The process runner</param>
+        /// <param name="globber">The globber</param>
+        public MDToolSetupRunner(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner, IGlobber globber) : base(fileSystem, environment, processRunner, globber)
+        {
+            _environment = environment;
+        }
+
+        /// <summary>Gets the name of the tool.</summary>
+        /// <returns>The name of the tool.</returns>
+        protected override string GetToolName() => "mdtool";
+
+        /// <summary>Gets the possible names of the tool executable.</summary>
+        /// <returns>The tool executable name.</returns>
+        protected override IEnumerable<string> GetToolExecutableNames()
+        {
+            yield return "mdtool";
+        }
+
+        /// <summary>
+        /// Creates a package from an add-in configuration file.
+        /// </summary>
+        /// <param name="addinFile">The addin file.</param>
+        public void Pack (FilePath addinFile)
+        {
+            var args = GetSetupBuilder();
+
+            args.Append("pack");
+            args.Append(addinFile.MakeAbsolute(_environment).FullPath.Quote());
+
+            Run(new MDToolSetupSettings(), args);
+        }
+
+        /// <summary>
+        /// Creates a package from an add-in configuration file, output to the specified directory.
+        /// </summary>
+        /// <param name="addinFile">The addin file.</param>
+        /// <param name="outputDirectory">The target directory for the package.</param>
+        public void Pack (FilePath addinFile, DirectoryPath outputDirectory)
+        {
+            var args = GetSetupBuilder();
+
+            args.Append("pack");
+            args.AppendQuoted(addinFile.MakeAbsolute(_environment).FullPath);
+            args.Append($"-d:{outputDirectory.FullPath.Quote()}");
+
+            Run(new MDToolSetupSettings(), args);
+        }
+
+        /// <summary>
+        /// Creates a repository index file for a directory structure.
+        /// </summary>
+        /// <param name="targetDirectory">Directory to scan.</param>
+        public void CreateRepositoryIndex (DirectoryPath targetDirectory)
+        {
+            var args = GetSetupBuilder();
+
+            args.Append("rb");
+            args.AppendQuoted(targetDirectory.FullPath);
+
+            Run(new MDToolSetupSettings(), args);
+        }
+
+        private ProcessArgumentBuilder GetSetupBuilder ()
+        {
+            var builder = new ProcessArgumentBuilder();
+            builder.Append("setup");
+            return builder;
+        }
+    }
+}

--- a/Cake.Xamarin/MDToolSetupSettings.cs
+++ b/Cake.Xamarin/MDToolSetupSettings.cs
@@ -1,0 +1,12 @@
+﻿using Cake.Core.Tooling;
+
+namespace Cake.Xamarin
+{
+    /// <summary>
+    /// Settings for the <see cref="MDToolSetupRunner"/>.
+    /// </summary>
+    public class MDToolSetupSettings : ToolSettings
+    {
+
+    }
+}


### PR DESCRIPTION
This PR adds basic/initial support for the `mdtool setup` tool.

Given the complexity of the setup utility and its child commands, I've hidden the whole thing behind a `MDToolSetup` property alias which does break pattern a little, but I think it's worth it for the simplicity.

Not all that familiar with this addin, so let me know if anything looks wrong, or if I need to change anything.