### PR TITLE
Add cross-platform mdtool executable names

### DIFF
--- a/Cake.Xamarin/MDToolRunner.cs
+++ b/Cake.Xamarin/MDToolRunner.cs
@@ -56,7 +56,10 @@ namespace Cake.Xamarin
 
         protected override IEnumerable<string> GetToolExecutableNames ()
         {
-            return new [] { "mdtool" };
+            yield return "mdtool";
+            yield return "mdtool.exe";
+            yield return "mdtool.cmd";
+            yield return "mdtool.sh";
         }
 
         protected override IEnumerable<FilePath> GetAlternativeToolPaths (MDToolSettings settings)

--- a/Cake.Xamarin/MDToolSetupRunner.cs
+++ b/Cake.Xamarin/MDToolSetupRunner.cs
@@ -33,6 +33,9 @@ namespace Cake.Xamarin
         protected override IEnumerable<string> GetToolExecutableNames()
         {
             yield return "mdtool";
+            yield return "mdtool.exe";
+            yield return "mdtool.cmd";
+            yield return "mdtool.sh";
         }
 
         /// <summary>


### PR DESCRIPTION
Adds support for both Windows and wrapper/package scripts when running `mdtool` commands.

Let me know if anything looks off.