### PR TITLE
Fixed wrong TestFixture agrument in TestCloudRunner

### DIFF
--- a/src/Cake.Xamarin/TestCloudRunner.cs
+++ b/src/Cake.Xamarin/TestCloudRunner.cs
@@ -178,7 +178,7 @@ namespace Cake.Xamarin
                 builder.Append ("--test-chunk");
 
             if (settings.TestFixture)
-                builder.Append ("--test-fixture");
+                builder.Append ("--fixture-chunk");
 
             Run (settings, builder);
         }


### PR DESCRIPTION
see issue #19 

The argument of TestCloud.exe for running test in parallel is wrong. Currently ir is "--test-fixture" but it must be "--fixture-chunk".

I fixed that :)